### PR TITLE
Fix some issues with clang compilation (related to order of includes)

### DIFF
--- a/src/Omega_h_expr.cpp
+++ b/src/Omega_h_expr.cpp
@@ -1,6 +1,5 @@
-#include <Teuchos_any.hpp>
-
 #include <Omega_h_expr.hpp>
+#include <Omega_h_matrix.hpp>
 
 #include <Teuchos_Language.hpp>
 #include <Teuchos_MathExpr.hpp>
@@ -9,6 +8,8 @@
 #include <Omega_h_loop.hpp>
 #include <Omega_h_matrix.hpp>
 #include <Omega_h_vector.hpp>
+
+#include <Teuchos_any.hpp>
 
 namespace Omega_h {
 

--- a/src/Omega_h_expr.hpp
+++ b/src/Omega_h_expr.hpp
@@ -5,8 +5,6 @@
 #include <map>
 #include <vector>
 
-#include <Teuchos_Reader.hpp>
-
 #include <Omega_h_array.hpp>
 #include <Omega_h_matrix.hpp>
 
@@ -16,6 +14,8 @@
 
 /* appease the non-standard crap in Teuchos::any */
 namespace Teuchos {
+  
+class any;
 
 template <Omega_h::Int dim>
 inline bool operator==(
@@ -67,6 +67,8 @@ inline std::ostream& operator<<(
 }
 
 }  // namespace Teuchos
+
+#include <Teuchos_Reader.hpp>
 
 namespace Omega_h {
 


### PR DESCRIPTION
Clang really wants all operator definitions to precede their use; fixed by moving the include of `Teuchos_any.hpp` later in `Omega_h_expr.cpp` and `Omega_h_expr.hpp`.