### PR TITLE
Avoid clang warning

### DIFF
--- a/src/Omega_h_indset.cpp
+++ b/src/Omega_h_indset.cpp
@@ -126,7 +126,7 @@ Read<I8> find_indset(
 
 Read<I8> find_indset(
     Mesh* mesh, Int ent_dim, Reals qualities, Bytes candidates) {
-  if (ent_dim == mesh->dim()) return candidates;
+  if (ent_dim == mesh->dim()) return std::move(candidates);
   mesh->owners_have_all_upward(ent_dim);
   OMEGA_H_CHECK(mesh->owners_have_all_upward(ent_dim));
   auto graph = mesh->ask_star(ent_dim);


### PR DESCRIPTION
```
<omega_h>/src/Omega_h_indset.cpp:129:38: error: local variable 'candidates' will be copied despite being returned by name [-Werror,-Wreturn-std-move]
  if (ent_dim == mesh->dim()) return candidates;
                                     ^~~~~~~~~~
<omega_h>/src/Omega_h_indset.cpp:129:38: note: call 'std::move' explicitly to avoid copying
  if (ent_dim == mesh->dim()) return candidates;
                                     ^~~~~~~~~~
                                     std::move(candidates)
1 error generated.
make[6]: *** [src/CMakeFiles/omega_h.dir/build.make:206: src/CMakeFiles/omega_h.dir/Omega_h_indset.cpp.o] Error 1
make[6]: *** Waiting for unfinished jobs....
make[5]: *** [CMakeFiles/Makefile2:335: src/CMakeFiles/omega_h.dir/all] Error 2
make[4]: *** [Makefile:141: all] Error 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibaned/omega_h/237)
<!-- Reviewable:end -->
