### PR TITLE
CMake: install Omega_h_refine.hpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -437,6 +437,7 @@ set(Omega_h_HEADERS
   Omega_h_amr.hpp
   Omega_h_stack.hpp
   Omega_h_owners.hpp
+  Omega_h_refine.hpp
   )
 
 if (NOT Omega_h_USE_CUDA)


### PR DESCRIPTION
This pull-request provides an additional header that was not published before.

@ibaned Are the other headers related to refinement meant to be public as well?