### PR TITLE
Expose box header to the install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -445,6 +445,7 @@ set(Omega_h_HEADERS
   Omega_h_stack.hpp
   Omega_h_owners.hpp
   Omega_h_rbtree.hpp
+  Omega_h_box.hpp
   )
 
 if (NOT Omega_h_USE_CUDA)


### PR DESCRIPTION
I would like to call build classification for  a box using `classify_box` and `get_box_sets` after building a box mesh with `build_box_internal` in an external application. The easiest way to do this seems to be installing the `Omega_h_box.hpp` header.