### PR TITLE
Amr derefine

### DIFF
--- a/src/Omega_h_amr.cpp
+++ b/src/Omega_h_amr.cpp
@@ -2,10 +2,13 @@
 #include <Omega_h_amr_topology.hpp>
 #include <Omega_h_amr_transfer.hpp>
 #include <Omega_h_for.hpp>
+#include <Omega_h_globals.hpp>
 #include <Omega_h_hypercube.hpp>
+#include <Omega_h_int_scan.hpp>
 #include <Omega_h_map.hpp>
 #include <Omega_h_mesh.hpp>
 #include <Omega_h_modify.hpp>
+#include <Omega_h_unmap_mesh.hpp>
 
 namespace Omega_h {
 
@@ -167,6 +170,27 @@ void refine(Mesh* mesh, Bytes elems_are_marked, TransferOpts xfer_opts) {
   amr::refine_ghosted(mesh);
   mesh->set_parting(OMEGA_H_ELEM_BASED);
   amr::refine_elem_based(mesh, xfer_opts);
+}
+
+void derefine(Mesh* mesh, Bytes elems_are_marked, TransferOpts xfer_opts) {
+  OMEGA_H_CHECK(mesh->family() == OMEGA_H_HYPERCUBE);
+  amr::tag_derefined(mesh, elems_are_marked);
+  LOs new_ents2old_ents[4];
+  GOs new_globals[4];
+  for (int ent_dim = 0; ent_dim <= mesh->dim(); ++ent_dim) {
+    auto does_ent_persist = mesh->get_array<Byte>(ent_dim, "persists");
+    auto old_ents2new_ents = offset_scan(does_ent_persist, "old_ents2new_ents");
+    auto nnew_ents = old_ents2new_ents.last();
+    mesh->remove_tag(ent_dim, "persists");
+    new_ents2old_ents[ent_dim] = invert_injective_map(old_ents2new_ents, nnew_ents);
+    auto old_ents2new_globals = rescan_globals(mesh, does_ent_persist);
+    new_globals[ent_dim] = unmap(new_ents2old_ents[ent_dim], old_ents2new_globals, 1);
+  }
+  unmap_mesh(mesh, new_ents2old_ents);
+  for (int ent_dim = 0; ent_dim <= mesh->dim(); ++ent_dim) {
+    mesh->set_tag(ent_dim, "global", new_globals[ent_dim]);
+  }
+  (void)xfer_opts;
 }
 
 }  // namespace amr

--- a/src/Omega_h_amr.hpp
+++ b/src/Omega_h_amr.hpp
@@ -21,6 +21,7 @@ OMEGA_H_INLINE constexpr I8 make_code(Int which_child, Int parent_dim) {
 Bytes enforce_2to1_refine(Mesh* mesh, Int bridge_dim, Bytes elems_are_marked);
 
 void refine(Mesh* mesh, Bytes elems_are_marked, TransferOpts xfer_opts);
+void derefine(Mesh* mesh, Bytes elems_are_marked, TransferOpts xfer_opts);
 
 }  // namespace amr
 

--- a/src/Omega_h_amr_topology.hpp
+++ b/src/Omega_h_amr_topology.hpp
@@ -12,6 +12,7 @@ class Mesh;
 namespace amr {
 
 void mark_refined(Mesh* mesh, Bytes elems_are_marked);
+void tag_derefined(Mesh* mesh, Bytes elems_are_marked);
 
 Few<LO, 4> count_refined(Mesh* mesh);
 

--- a/src/Omega_h_unmap_mesh.cpp
+++ b/src/Omega_h_unmap_mesh.cpp
@@ -63,7 +63,9 @@ void unmap_owners(Mesh* old_mesh, Mesh* new_mesh, Int ent_dim,
 
 void unmap_mesh(Mesh* mesh, LOs new_ents2old_ents[]) {
   auto new_mesh = mesh->copy_meta();
-  new_mesh.set_verts(mesh->nverts());
+  auto nnew_verts = (new_ents2old_ents[0].exists()) ?
+    new_ents2old_ents[0].size() : mesh->nverts();
+  new_mesh.set_verts(nnew_verts);
   LOs old_lows2new_lows;
   for (Int ent_dim = 0; ent_dim <= mesh->dim(); ++ent_dim) {
     if (ent_dim > VERT) {

--- a/src/amr_test2.cpp
+++ b/src/amr_test2.cpp
@@ -44,14 +44,18 @@ static void run_2D_adapt(Omega_h::Library* lib) {
   auto w = lib->world();
   auto f = OMEGA_H_HYPERCUBE;
   auto m = Omega_h::build_box(w, f, 1.0, 1.0, 0.0, 2, 2, 0);
-  Omega_h::vtk::Writer writer("out_amr_2D", &m);
+  Omega_h::vtk::FullWriter writer("out_amr_2D", &m);
   writer.write();
-  for (int i = 1; i < 5; ++i) {
-    auto xfer_opts = Omega_h::TransferOpts();
-    auto marks = mark<2>(&m, i);
-    Omega_h::amr::refine(&m, marks, xfer_opts);
-    writer.write();
-  }
+  // refine
+  Omega_h::Write<Omega_h::Byte> refine_marks(m.nelems(), 1);
+  auto xfer_opts = Omega_h::TransferOpts();
+  Omega_h::amr::refine(&m, refine_marks, xfer_opts);
+  writer.write();
+  // de-refine
+  Omega_h::Write<Omega_h::Byte> derefine_marks(m.nelems(), 0);
+  derefine_marks.set(0, 1);
+  Omega_h::amr::derefine(&m, derefine_marks, xfer_opts);
+  writer.write();
 }
 
 static void run_3D_adapt(Omega_h::Library* lib) {


### PR DESCRIPTION
Some notes:

* Missing unmapping of parents, which I'll do in another feature branch
* Unmapping of globals happens inside of [`amr::derefine`](https://github.com/ibaned/omega_h/commit/39ee164c111e589992d06955b00ae0a8de8217b7#diff-1a98c96814ad48750c38cf408bc41597R179). This logic could be moved to unmap mesh if it seems like a good idea, though.
