### PR TITLE
Fix compilation w/ clang

### DIFF
--- a/src/Omega_h_input.cpp
+++ b/src/Omega_h_input.cpp
@@ -358,7 +358,14 @@ class InputYamlReader : public Reader {
         OMEGA_H_CHECK(rhs.at(0).type() == typeid(NameValue));
         auto result_any = map_first_item(rhs.at(0));
         OMEGA_H_CHECK(result_any.type() == typeid(InputMap));
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpessimizing-move"
+#endif
         return std::move(result_any);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
       }
       case yaml::PROD_BMAP_NEXT: {
         return map_next_item(rhs.at(0), rhs.at(1));


### PR DESCRIPTION
This is a (maybe temporary) fix for the compilation error below w/ clang:

```
/Users/bngranz/jughead/src/omega_h/src/Omega_h_input.cpp:361:16: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
        return std::move(result_any);
               ^
/Users/bngranz/jughead/src/omega_h/src/Omega_h_input.cpp:361:16: note: remove std::move call here
        return std::move(result_any);
```