### PR TITLE
Mark closures with graphs

### DIFF
--- a/src/Omega_h_mark.hpp
+++ b/src/Omega_h_mark.hpp
@@ -28,8 +28,14 @@ Read<I8> mark_class_closure(
 Read<I8> mark_class_closures(Mesh* mesh, Int ent_dim, Int class_dim,
     std::vector<ClassId> const& class_ids);
 
+Read<I8> mark_class_closures(Mesh* mesh, Int class_dim,
+    std::vector<ClassId> const& class_ids, Graph nodes2ents);
+
 Read<I8> mark_class_closures(
     Mesh* mesh, Int ent_dim, std::vector<ClassPair> const& class_pairs);
+
+Read<I8> mark_class_closures(Mesh* mesh,
+    std::vector<ClassPair> const& class_pairs, Graph nodes2ents[4]);
 
 template <typename T>
 OMEGA_H_DEVICE Int binary_search(Read<T> const& a, T v, LO n) {

--- a/src/Omega_h_mark.hpp
+++ b/src/Omega_h_mark.hpp
@@ -8,6 +8,7 @@
 
 namespace Omega_h {
 
+Read<I8> mark_down(Graph low2high, Read<I8> marked_highs);
 Read<I8> mark_down(
     Mesh* mesh, Int high_dim, Int low_dim, Read<I8> marked_highs);
 Read<I8> mark_up(Mesh* mesh, Int low_dim, Int high_dim, Read<I8> low_marked);

--- a/src/Omega_h_mesh.cpp
+++ b/src/Omega_h_mesh.cpp
@@ -802,8 +802,8 @@ void ask_for_mesh_tags(Mesh* mesh, TagSet const& tags) {
   if (tags[size_t(mesh->dim())].count("quality")) mesh->ask_qualities();
 }
 
-LOs ents_on_closure(
-    Mesh* mesh, std::set<std::string> const& class_names, Int ent_dim) {
+static std::vector<ClassPair> to_class_pairs(Mesh* mesh,
+    std::set<std::string> const& class_names) {
   std::set<ClassPair> class_pairs;
   for (auto& cn : class_names) {
     auto it = mesh->class_sets.find(cn);
@@ -819,8 +819,21 @@ LOs ents_on_closure(
   }
   std::vector<ClassPair> class_pair_vector(
       class_pairs.begin(), class_pairs.end());
-  auto ents_are_on = mark_class_closures(mesh, ent_dim, class_pair_vector);
+  return class_pair_vector;
+}
+
+LOs ents_on_closure(
+    Mesh* mesh, std::set<std::string> const& class_names, Int ent_dim) {
+  auto class_pairs = to_class_pairs(mesh, class_names);
+  auto ents_are_on = mark_class_closures(mesh, ent_dim, class_pairs);
   return collect_marked(ents_are_on);
+}
+
+LOs nodes_on_closure(Mesh* mesh,
+    std::set<std::string> const& class_names, Graph nodes2ents[4]) {
+  auto class_pairs = to_class_pairs(mesh, class_names);
+  auto nodes_are_on = mark_class_closures(mesh, class_pairs, nodes2ents);
+  return collect_marked(nodes_are_on);
 }
 
 #ifdef OMEGA_H_USE_CUDA

--- a/src/Omega_h_mesh.hpp
+++ b/src/Omega_h_mesh.hpp
@@ -186,6 +186,9 @@ void reorder_by_globals(Mesh* mesh);
 LOs ents_on_closure(
     Mesh* mesh, std::set<std::string> const& class_names, Int ent_dim);
 
+LOs nodes_on_closure(Mesh* mesh,
+    std::set<std::string> const& class_names, Graph nodes2ents[4]);
+
 // workaround CUDA compiler bug
 #ifdef OMEGA_H_USE_CUDA
 __host__


### PR DESCRIPTION
Untested as of yet, but all previous functionality appears to remain the same as all Omega_h and downstream LGR tests still pass.